### PR TITLE
Fix XML saving and filter

### DIFF
--- a/bot_with_plan_monitor.py
+++ b/bot_with_plan_monitor.py
@@ -252,10 +252,14 @@ async def check() -> None:
                 continue
 
         prev = load_json(day)
+        xml_first = not any(DIR.glob(f"{day:%Y%m%d}*.xml"))
+        xml_str = vp.filtered_xml(xml_bytes)
+        if xml_first:
+            save_xml(day, xml_str)
 
         if prev is None:
             save_json(day, mine)
-            save_xml(day, vp.filtered_xml(xml_bytes))
+            save_xml(day, xml_str)
             out.append(f"📅 {day:%d.%m.%Y} – neuer Plan ({len(mine)})")
             logging.info(f"[Neuer Plan] {day:%Y-%m-%d} – {len(mine)} Einträge geladen")
             continue
@@ -305,7 +309,7 @@ async def check() -> None:
             out.append(block)
             logging.info(f"[Planänderung] {day:%Y-%m-%d}\n" + "\n".join(rc_msgs))
             save_json(day, mine)
-            save_xml(day, vp.filtered_xml(xml_bytes))
+            save_xml(day, xml_str)
 
 
     prune_logs(10)

--- a/tests/test_vp.py
+++ b/tests/test_vp.py
@@ -142,3 +142,31 @@ def test_filtered_xml():
     kl = ET.fromstring(result)
     stds = kl.findall('.//Std')
     assert len(stds) == 2  # MUS sollte entfernt sein
+
+
+def test_ignore_unrelated_kun_raue():
+    entry = {
+        "stunde": 1,
+        "beginn": None,
+        "ende": None,
+        "fach": "KUN5",
+        "kurs": None,
+        "lehrer": "RAUE",
+        "raum": None,
+        "info": None,
+    }
+    assert vp.keep(entry) is False
+
+
+def test_ignore_info_only_teacher():
+    entry = {
+        "stunde": 1,
+        "beginn": None,
+        "ende": None,
+        "fach": "---",
+        "kurs": "KUN5",
+        "lehrer": None,
+        "raum": None,
+        "info": "Vertretung RAUE",
+    }
+    assert vp.keep(entry) is False

--- a/vp_10e_plan.py
+++ b/vp_10e_plan.py
@@ -64,9 +64,11 @@ MY_COURSES: set[tuple[str, str]] = {
 MY_KURSE: set[str] = {k for k, _ in MY_COURSES}
 MY_LEHRER: set[str] = {l for _, l in MY_COURSES}
 SUBJECTS:  set[str] = {f for f, _ in MY_COURSES}
-INFO_RE = re.compile(
-    "|".join(re.escape(x) for x in MY_KURSE | MY_LEHRER), re.IGNORECASE
-)
+
+# Nur Kurskürzel für die Info-Suche verwenden. Dadurch werden Einträge wie
+# "KUN5 RAUE" nicht versehentlich berücksichtigt, nur weil der Lehrername
+# vorkommt.
+INFO_RE = re.compile("|".join(re.escape(x) for x in MY_KURSE), re.IGNORECASE)
 
 
 # ---------------------------------------------------------------------------
@@ -180,7 +182,7 @@ def keep(e: dict) -> bool:
 
     # Ausfall-Zeile: fach == '---'
     if fach == "---":
-        return (
+        return bool(
             kurs in MY_KURSE
             or kurs in SUBJECTS      # z. B. "DEU"
             or INFO_RE.search(info)


### PR DESCRIPTION
## Summary
- ensure at least one filtered XML is stored per day
- filter only by course codes in info text to prevent unrelated entries
- return bool from `keep` in absence of matches
- cover new behaviour in tests

## Testing
- `pytest -q`