### PR TITLE
Fix repeated XML log saving

### DIFF
--- a/bot_with_plan_monitor.py
+++ b/bot_with_plan_monitor.py
@@ -106,6 +106,15 @@ def _next_xml_path(day: dt.date) -> pathlib.Path:
 def save_xml(day: dt.date, xml_str: str | None) -> None:
     if not xml_str:
         return
+
+    existing = sorted(DIR.glob(f"{day:%Y%m%d}*.xml"))
+    if existing:
+        try:
+            if existing[-1].read_text(encoding="utf-8") == xml_str:
+                return
+        except OSError:
+            pass
+
     path = _next_xml_path(day)
     path.write_text(xml_str, encoding="utf-8")
 

--- a/tests/test_vp.py
+++ b/tests/test_vp.py
@@ -170,3 +170,20 @@ def test_ignore_info_only_teacher():
         "info": "Vertretung RAUE",
     }
     assert vp.keep(entry) is False
+
+def test_save_xml_dedup(monkeypatch, tmp_path):
+    day = dt.date(2025, 5, 28)
+    monkeypatch.setattr(bot, "DIR", tmp_path)
+    monkeypatch.setattr(bot, "XML_PF", lambda d, n=1: tmp_path / f"{d:%Y%m%d}{'' if n == 1 else '_' + str(n)}.xml")
+
+    bot.save_xml(day, "<a/>")
+    assert (tmp_path / "20250528.xml").exists()
+
+    # same content should not create a new file
+    bot.save_xml(day, "<a/>")
+    assert not (tmp_path / "20250528_2.xml").exists()
+
+    # different content -> new file
+    bot.save_xml(day, "<b/>")
+    assert (tmp_path / "20250528_2.xml").exists()
+


### PR DESCRIPTION
## Summary
- avoid repeated XML file writes when contents are unchanged
- test XML deduplication logic

## Testing
- `pytest -q`