### PR TITLE
Add env variable for bot check interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Dieser Bot überwacht den Vertretungsplan einer Schule und sendet Änderungen in
    PLAN_CHANNEL_ID=...
    ```
    # optionale Einstellungen
+   CHECK_SECONDS=30   # wie oft der Plan abgefragt wird
    SHOW_TICK=false   # Kopfzeile bei jedem Tick senden
    SHOW_RES=false    # XML-Auszug der Klasse 10E ins Log schreiben
    FAKE_DATE=YYYYMMDD  # Testdatum statt heutigem Datum

--- a/bot_with_plan_monitor.py
+++ b/bot_with_plan_monitor.py
@@ -29,6 +29,12 @@ import vp_10e_plan as vp
 vp.mine = vp.keep
 load_dotenv()
 
+# Intervall für den Plan-Check aus der Umgebung laden
+try:
+    CHECK_SECONDS: float = float(os.getenv("CHECK_SECONDS", "30"))
+except ValueError:
+    CHECK_SECONDS = 30.0
+
 def _canon(s: str) -> str:
     """Unicode-normalisieren, überflüssige Leerzeichen killen."""
     return _ud.normalize("NFC", " ".join(s.split()))
@@ -223,7 +229,7 @@ def room_change(old: dict, new: dict) -> Optional[str]:
 # ---------------------------------------------------------------------------
 # Haupt-Task
 # ---------------------------------------------------------------------------
-@tasks.loop(seconds=30)
+@tasks.loop(seconds=CHECK_SECONDS)
 async def check() -> None:
     ch = bot.get_channel(CHANNEL_ID)
     if ch is None:

--- a/tests/test_vp.py
+++ b/tests/test_vp.py
@@ -9,6 +9,7 @@ os.environ.setdefault('VP_PASS', 'pass')
 os.environ.setdefault('VP_BASE_URL', 'https://example.com')
 os.environ.setdefault('DISCORD_TOKEN', 'token')
 os.environ.setdefault('PLAN_CHANNEL_ID', '1')
+os.environ.setdefault('CHECK_SECONDS', '30')
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))


### PR DESCRIPTION
## Summary
- support `CHECK_SECONDS` env var for controlling how often the bot checks the plan
- document new variable in README
- adapt tests to set `CHECK_SECONDS`

## Testing
- `pytest -q`